### PR TITLE
Config/7 configuracao inicial swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,25 @@
 	mvn spring-boot:run
 	```
 
-## Observações
 
-- As configurações de conexão estão protegidas no arquivo `application.properties` e usam variáveis do `.env`.
-- Não é necessário configuração adicional.
-- A API estará disponível na porta padrão configurada.
+## Documentação da API com Swagger
+
+Esta API utiliza o Swagger para documentação e testes interativos dos endpoints.
+
+### Como acessar o Swagger
+
+Após iniciar a aplicação, acesse:
+
+- Interface Swagger UI: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+- Documentação dos endpoints: [http://localhost:8080/api-docs](http://localhost:8080/api-docs)
+
+
+
+O Swagger é uma ferramenta essencial para APIs REST, pois:
+
+- Permite explorar todos os endpoints de forma visual e interativa.
+- Facilita o teste das operações diretamente pelo navegador, sem necessidade de ferramentas externas.
+- Exibe exemplos de requisição e resposta, parâmetros e modelos de dados.
+- Ajuda desenvolvedores e equipes a entenderem rapidamente como utilizar a API.
+
+Com o Swagger, qualquer pessoa pode experimentar os recursos do CRUD, validar integrações e aprender sobre a API sem precisar consultar a documentação técnica tradicional.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,6 +65,11 @@
 			<artifactId>spring-dotenv</artifactId>
 			<version>3.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,12 +1,20 @@
+# Configuração geral da aplicação
 spring.application.name=neohorizon
 
+# Configurações de acesso ao banco de dados PostgreSQL
 spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# Configurações do JPA/Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
+# Caminho do arquivo de variáveis de ambiente
 .env_FILE=./.env
+
+# Configurações do Swagger para documentação da API
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
Este PR realiza a configuração inicial do Swagger na API, permitindo a documentação automática dos endpoints REST. Foram realizadas as seguintes alterações:

- Adicionada a dependência do Swagger no pom.xml
- Configuradas as propriedades necessárias no application.properties
- Atualizado o README.md com instruções de uso do Swagger

Como testar:

- Execute o projeto. 

- Acesse a interface do Swagger em: http://localhost:8080/swagger-ui.html
<img width="1598" height="870" alt="image" src="https://github.com/user-attachments/assets/31156c75-fe01-4bbf-9dfb-d45786b0e37f" />


- Verifique se os endpoints estão documentados corretamente.