### PR TITLE
feat(#21): Endpoint de horas totais e por projeto

### DIFF
--- a/api/src/main/java/com/neohorizon/api/controller/FatoCustoHoraController.java
+++ b/api/src/main/java/com/neohorizon/api/controller/FatoCustoHoraController.java
@@ -1,6 +1,9 @@
 package com.neohorizon.api.controller;
 
 import com.neohorizon.api.dto.FatoCustoHoraDTO;
+import com.neohorizon.api.entity.DimDev;
+import com.neohorizon.api.entity.DimPeriodo;
+import com.neohorizon.api.entity.DimProjeto;
 import com.neohorizon.api.service.FatoCustoHoraService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 
 @RestController
 @RequestMapping("/fato-custo-hora")
@@ -20,6 +26,42 @@ public class FatoCustoHoraController {
     public FatoCustoHoraController(FatoCustoHoraService fatoCustoHoraService) {
         this.fatoCustoHoraService = fatoCustoHoraService;
     }
+
+    @GetMapping("/filter")
+    public ResponseEntity<List<FatoCustoHoraDTO>> getAllEntitiesByFilter(
+        @RequestParam Long projeto_id,
+        @RequestParam Long periodo_id,
+        @RequestParam Long dev_id) {
+
+        DimProjeto dimProjeto = new DimProjeto();
+        DimPeriodo dimPeriodo = new DimPeriodo();
+        DimDev dimDev = new DimDev();
+
+       
+        dimProjeto.setId(projeto_id);
+        dimPeriodo.setId(periodo_id);
+        dimDev.setId(dev_id);
+       
+       
+        if(periodo_id == 0)
+        {
+            dimPeriodo = null;
+        }
+
+        if(projeto_id == 0)
+        {
+            dimProjeto = null;
+        }
+
+        if(dev_id == 0)
+        {
+            dimDev = null;
+        }
+
+        List<FatoCustoHoraDTO> fatoCustoHoraDTOs = fatoCustoHoraService.getAllEntitiesByFilter(dimProjeto,dimPeriodo, dimDev);
+        return ResponseEntity.ok(fatoCustoHoraDTOs);
+    }
+    
 
     @GetMapping
     public ResponseEntity<List<FatoCustoHoraDTO>> getAllEntities(

--- a/api/src/main/java/com/neohorizon/api/entity/FatoCustoHora.java
+++ b/api/src/main/java/com/neohorizon/api/entity/FatoCustoHora.java
@@ -16,15 +16,15 @@ public class FatoCustoHora {
     @Column(name = "custo_hora_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade=CascadeType.PERSIST)
     @JoinColumn(name = "projeto_id", nullable = false)
     private DimProjeto dimProjeto;
 
-    @ManyToOne
+    @ManyToOne(cascade=CascadeType.PERSIST)
     @JoinColumn(name = "periodo_id", nullable = false)
     private DimPeriodo dimPeriodo;
 
-    @ManyToOne
+    @ManyToOne(cascade=CascadeType.PERSIST)
     @JoinColumn(name = "dev_id", nullable = false)
     private DimDev dimDev;
 

--- a/api/src/main/java/com/neohorizon/api/repository/FatoCustoHoraRepository.java
+++ b/api/src/main/java/com/neohorizon/api/repository/FatoCustoHoraRepository.java
@@ -1,8 +1,19 @@
 package com.neohorizon.api.repository;
 
+import com.neohorizon.api.entity.DimDev;
+import com.neohorizon.api.entity.DimPeriodo;
+import com.neohorizon.api.entity.DimProjeto;
 import com.neohorizon.api.entity.FatoCustoHora;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FatoCustoHoraRepository extends JpaRepository<FatoCustoHora, Long>  {
 
+    @Query("SELECT f FROM FatoCustoHora f WHERE (:dimProjeto is null or f.dimProjeto = :dimProjeto) and (:dimPeriodo is null"
+  + " or f.dimPeriodo = :dimPeriodo) and (:dimDev is null or f.dimDev = :dimDev)")
+    public List<FatoCustoHora> findByDimProjetoAndDimPeriodoAndDimDev(@Param("dimProjeto") DimProjeto dimProjeto, @Param("dimPeriodo") DimPeriodo dimPeriodo, @Param("dimDev") DimDev dimDev);
 }

--- a/api/src/main/java/com/neohorizon/api/service/FatoCustoHoraService.java
+++ b/api/src/main/java/com/neohorizon/api/service/FatoCustoHoraService.java
@@ -1,6 +1,9 @@
 package com.neohorizon.api.service;
 
 import com.neohorizon.api.dto.FatoCustoHoraDTO;
+import com.neohorizon.api.entity.DimDev;
+import com.neohorizon.api.entity.DimPeriodo;
+import com.neohorizon.api.entity.DimProjeto;
 import com.neohorizon.api.entity.FatoCustoHora;
 import com.neohorizon.api.repository.FatoCustoHoraRepository;
 
@@ -18,6 +21,14 @@ public class FatoCustoHoraService {
     @Autowired
     public FatoCustoHoraService(FatoCustoHoraRepository fatoCustoHoraRepository) {
         this.fatoCustoHoraRepository = fatoCustoHoraRepository;
+    }
+
+    public List<FatoCustoHoraDTO> getAllEntitiesByFilter(DimProjeto dimProjeto, DimPeriodo dimPeriodo, DimDev dimDev)
+    {
+        return fatoCustoHoraRepository.findByDimProjetoAndDimPeriodoAndDimDev(dimProjeto, dimPeriodo, dimDev)
+                .stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
     }
 
     public List<FatoCustoHoraDTO> getAllEntities() {


### PR DESCRIPTION
#21

Endpoint para retornar o total de horas filtrado por projeto, período e/ou desenvolvedor

Caso queria ignorar algum filtro (por exemplo, buscar todas as fato_custo_hora para um único dev independente do período e do projeto) deve-se colocar o parâmetro do filtro como 0

<img width="699" height="822" alt="image" src="https://github.com/user-attachments/assets/d40e967e-2696-4572-8bde-d2dd0a956f0e" />
